### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: build-openlane-sky130
+on: [push]
+
+jobs:
+  build-openlane:
+    runs-on: ubuntu-latest
+    env:
+      REPO : clockless-inverter
+      VLNV : inverter
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: clockless-inverter
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : clockless-inverter
+      VLNV : inverter
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: clockless-inverter
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/data/params.tcl
+++ b/data/params.tcl
@@ -1,0 +1,11 @@
+# turn off clock
+set ::env(CLOCK_TREE_SYNTH) 0
+set ::env(CLOCK_PORT) ""
+
+set ::env(PL_SKIP_INITIAL_PLACEMENT) 1
+set ::env(PL_RANDOM_GLB_PLACEMENT) 1
+set ::env(FP_SIZING) absolute
+set ::env(DIE_AREA) "0 0 34.165 54.885"
+set ::env(PL_TARGET_DENSITY) 0.75
+set ::env(FP_HORIZONTAL_HALO) 6
+set ::env(FP_VERTICAL_HALO) $::env(FP_HORIZONTAL_HALO)

--- a/inverter.core
+++ b/inverter.core
@@ -1,0 +1,31 @@
+CAPI=2:
+
+name : ::inverter:1.0.0
+
+filesets:
+  rtl:
+    files:
+      - src/inverter.v
+    file_type : verilogSource
+    
+  openlane:
+    files:
+      - data/params.tcl
+    file_type : tclSource
+
+targets:
+  default:
+    filesets : [rtl]
+
+  lint:
+    default_tool: verilator
+    filesets : [rtl]
+    tools:
+      verilator:
+        mode: lint-only
+    toplevel : inverter
+        
+  sky130:
+    default_tool : openlane
+    filesets : [rtl, openlane]
+    toplevel: inverter


### PR DESCRIPTION
This adds a core description file for the inverter core that exposes targets for linting and for building a GDSII using OpenLANE. All targets are also implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register $core as a library in the workspace
fusesoc library add inverter /path/to/inverter
 #...if repo is available locally or...
fusesoc library add inverter https://github.com/mattvenn/clockless-inverter
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint inverter
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 inverter
 #List all targets
fusesoc core show inverter